### PR TITLE
feat: install only `make`

### DIFF
--- a/config.make.yaml
+++ b/config.make.yaml
@@ -1,2 +1,2 @@
 #ddev-generated
-webimage_extra_packages: [build-essential]
+webimage_extra_packages: [make]


### PR DESCRIPTION
## The Issue

The `config.make.yaml` template, when used, currently adds the `build-essential` meta-package to the web container via `webimage_extra_packages`. While `build-essential` provides a comprehensive set of development tools (including `make`, `gcc`, `g++`, `dpkg-dev`, etc.), it is a very large package.

For many typical DDEV use cases where a `Makefile` is present (e.g., running `make` commands in Composer scripts, custom build steps), only the `make` utility itself is actually required. Installing the entire `build-essential` suite unnecessarily increases the web container image size and prolongs image build/update times.

## How This PR Solves The Issue

This PR changes the default `webimage_extra_packages` in `config.make.yaml` from `build-essential` to `make`.

This change provides a more lightweight default for projects that only need `make`. It significantly reduces the size of the web container image and speeds up the `ddev start` process, especially when images need to be rebuilt or provisioned.

For users who genuinely require the full `build-essential` suite (e.g., for compiling C/C++ extensions or other native dependencies), they can easily add `build-essential` back to their project's `.ddev/config.yaml` or a custom `.ddev/config.*.yaml` file.

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->
